### PR TITLE
Fix tab in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ install:
 
 .PHONY: passport
 passport:
-    docker-compose exec abr-app-api chmod -R 777 /app/storage
+	docker-compose exec abr-app-api chmod -R 777 /app/storage
 	docker-compose exec abr-app-api php artisan passport:install
 
 .PHONY: build-prod


### PR DESCRIPTION
Fixes the following error:

```bash
$ make build-dev
Makefile:32: *** missing separator.  Stop.
```